### PR TITLE
add comment_count to article response object from GET /api/articles/:article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -60,13 +60,14 @@ describe("GET /api/articles/:article_id", () => {
                     "article_id",
                     givenParameter // checks the recieved article_id is the given parameter.
                 );
-                expect(body.article).toHaveProperty("author");
-                expect(body.article).toHaveProperty("title");
-                expect(body.article).toHaveProperty("body");
-                expect(body.article).toHaveProperty("topic");
-                expect(body.article).toHaveProperty("created_at");
-                expect(body.article).toHaveProperty("votes");
-                expect(body.article).toHaveProperty("article_img_url");
+                expect(typeof body.article.author).toBe("string");
+                expect(typeof body.article.title).toBe("string");
+                expect(typeof body.article.body).toBe("string");
+                expect(typeof body.article.topic).toBe("string");
+                expect(typeof body.article.created_at).toBe("string");
+                expect(typeof body.article.votes).toBe("number");
+                expect(typeof body.article.article_img_url).toBe("string");
+                expect(typeof body.article.comment_count).toBe('number')
             });
     });
     test("status: 400, returns status error and msg if given parameter is not a number", () => {
@@ -280,6 +281,7 @@ describe("PATCH /api/articles/:article_id", () => {
                 expect(typeof body.article.body).toBe("string");
                 expect(typeof body.article.created_at).toBe("string");
                 expect(typeof body.article.article_img_url).toBe("string");
+                expect(typeof body.article.comment_count).toBe('number')
                 expect(body.article.votes).toBe(voteUpdate.inc_votes);
             });
     });
@@ -315,6 +317,8 @@ describe("PATCH /api/articles/:article_id", () => {
                         expect(typeof body.article.article_img_url).toBe(
                             "string"
                         );
+                        expect(typeof body.article.comment_count).toBe('number')
+                        
                         // expect votes to be initial votes plus the negative votes patch update
                         expect(body.article.votes).toBe(
                             initialVotes + negativeVotes

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,34 @@ const db = require(`${__dirname}/../db/connection`);
 
 exports.selectArticleById = (article_id) => {
     return db
-        .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+        .query(`SELECT
+            articles.article_id,
+            articles.author,
+            articles.title,
+            articles.body,
+            articles.topic,
+            articles.created_at,
+            articles.votes,
+            articles.article_img_url,
+            CAST(COUNT(comments.comment_id)AS int) AS comment_count
+        FROM
+            articles
+        LEFT JOIN
+            comments
+        ON
+            articles.article_id = comments.article_id
+        WHERE
+            articles.article_id = $1
+        GROUP BY
+            articles.article_id,
+            articles.author,
+            articles.title,
+            articles.body,
+            articles.topic,
+            articles.created_at,
+            articles.votes,
+            articles.article_img_url
+            `, [article_id])
         .then((databaseQuery) => {
             if (databaseQuery.rows.length === 0) {
                 return Promise.reject({
@@ -60,7 +87,7 @@ exports.updateArticleVotes = (article_id, inc_votes) => {
         RETURNING *`,
             [inc_votes, article_id]
         )
-        .then((databaseUpdate) => {
-            return databaseUpdate.rows[0];
+        .then(() => {
+            return this.selectArticleById(article_id)
         });
 };


### PR DESCRIPTION
Adds comment_count to served object when using GET request on /api/articles:article_id endpoint. Also adds this to other relevant requests that serve an article object. 