### PR TITLE
add sorting queries to GET request at /api/articles endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -478,3 +478,62 @@ describe("FEATURE (query article by topic): GET /api/articles?topic=", () => {
     })
     
 });
+
+describe("FEATURE (sorting queries): GET /api/articles?sort_by=&order=", () => {
+    test("status: 200, sorts articles by any valid column if given valid sort_by query and defaults to descending order", () => {
+        const validColumn = 'comment_count';
+        return request(app)
+        .get(`/api/articles?sort_by=${validColumn}`)
+        .expect(200)
+        .then(({body}) => {
+            expect(body.articles).toBeSortedBy(validColumn, {descending: true});
+        })
+    })
+    test("status 200, returns articles in ascending order when passed valid ascending order query", () => {
+        const ascOrderQuery = '?order=asc';
+        return request(app)
+        .get(`/api/articles${ascOrderQuery}`)
+        .expect(200)
+        .then(({body}) => {
+            expect(body.articles).toBeSortedBy('created_at', {descending: false})
+        })
+    })
+    test("status 200, returns articles in descending order when passed valid descending order query", () => {
+        const descOrderQuery = '?order=desc';
+        return request(app)
+        .get(`/api/articles${descOrderQuery}`)
+        .expect(200)
+        .then(({body}) => {
+            expect(body.articles).toBeSortedBy('created_at', {descending: true})
+        })
+    })
+    test("status 200, can return articles in ascending order sorted by a valid column", () => {
+        const validSortQuery = 'sort_by=author'
+        const ascOrderQuery = 'order=asc';
+        return request(app)
+        .get(`/api/articles?${validSortQuery}&${ascOrderQuery}`)
+        .expect(200)
+        .then(({body}) => {
+            console.log(body.articles)
+            expect(body.articles).toBeSortedBy('author', {descending: false})
+        })
+    })
+    test("status: 400, returns an error status and msg if sort_by query is not a valid column in the database", () => {
+        const nonValidColumn = 'forklift_count';
+        return request(app)
+        .get(`/api/articles?sort_by=${nonValidColumn}`)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("ERROR: invalid sort query")
+        })
+    })
+    test("status: 400, returns an error status and msg if order by query is invalid", () => {
+        const nonValidOrderQuery = 'ascending'  // valid order query is asc (or ASC)
+        return request(app)
+        .get(`/api/articles?order=${nonValidOrderQuery}`)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("ERROR: invalid order query")
+        })
+    })
+})

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -16,10 +16,10 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-    const { topic } = req.query;
+    const { topic, sort_by, order} = req.query;
     const promises = [
         inTopicList(topic),
-        selectArticles(topic)
+        selectArticles(topic, sort_by, order)
     ]
     Promise.all(promises)
         .then((returnedPromises) => {

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,8 @@ const db = require(`${__dirname}/../db/connection`);
 
 exports.selectArticleById = (article_id) => {
     return db
-        .query(`SELECT
+        .query(
+            `SELECT
             articles.article_id,
             articles.author,
             articles.title,
@@ -29,7 +30,9 @@ exports.selectArticleById = (article_id) => {
             articles.created_at,
             articles.votes,
             articles.article_img_url
-            `, [article_id])
+            `,
+            [article_id]
+        )
         .then((databaseQuery) => {
             if (databaseQuery.rows.length === 0) {
                 return Promise.reject({
@@ -41,7 +44,30 @@ exports.selectArticleById = (article_id) => {
         });
 };
 
-exports.selectArticles = (topic = "") => {
+exports.selectArticles = (topic = "", sort_by = "created_at", order = 'DESC') => {
+    const columns = [
+        "author",
+        "title",
+        "topic",
+        "created_at",
+        "votes",
+        "article_img_url",
+        "comment_count",
+    ];
+    if (!columns.includes(sort_by)) {
+        return Promise.reject({
+            status: 400,
+            msg: "ERROR: invalid sort query",
+        });
+    }
+    if (columns.slice(0, -1).includes(sort_by)) {
+        sort_by = `articles.${sort_by}`;
+    }
+
+    if (!['ASC', 'DESC'].includes(order.toUpperCase())) {
+        return Promise.reject({status: 400, msg: 'ERROR: invalid order query'})
+    }
+
     let dbQuery = `SELECT
         articles.author,
         articles.title,
@@ -71,7 +97,7 @@ exports.selectArticles = (topic = "") => {
             articles.created_at,
             articles.votes,
             articles.article_img_url
-        ORDER BY articles.created_at DESC`;
+        ORDER BY ${sort_by} ${order}`;
     return db.query(dbQuery).then((databaseQuery) => {
         return databaseQuery.rows;
     });
@@ -88,6 +114,6 @@ exports.updateArticleVotes = (article_id, inc_votes) => {
             [inc_votes, article_id]
         )
         .then(() => {
-            return this.selectArticleById(article_id)
+            return this.selectArticleById(article_id);
         });
 };


### PR DESCRIPTION
Can now use **_sort_by_** and **_order_** queries when using **GET** request on `/api/articles` endpoint.