### PR TITLE
add pagination to GET method at /api/articles endpoint

### DIFF
--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -16,14 +16,14 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-    const { topic, sort_by, order} = req.query;
+    const { topic, sort_by, order, limit, p} = req.query;
     const promises = [
         inTopicList(topic),
-        selectArticles(topic, sort_by, order)
+        selectArticles(topic, sort_by, order, limit, p)
     ]
     Promise.all(promises)
         .then((returnedPromises) => {
-            res.status(200).send({ articles: returnedPromises[1] });
+            res.status(200).send({ articles: returnedPromises[1].articles, total_count:  returnedPromises[1].total_count});
         })
         .catch(next)
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,8 +10,8 @@
         }
     },
     "GET /api/articles": {
-        "description": "serves an array of all articles",
-        "queries": ["author", "topic", "sort_by", "order"],
+        "description": "serves an array of all articles (auto limits to 10 articles)",
+        "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
         "exampleResponse": {
             "articles": [
                 {


### PR DESCRIPTION
Returned articles from the /api/articles endpoint (using GET) can be limited to a specified number per page (defaults to 10) using a _**?limit=**_ query. A **_?p=_** query can set the starting page (defaults to 1).